### PR TITLE
specify husky version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ function addHooks {
     y|Y )
       echo "Installing husky and lint-staged packages..."
 
-      eval "npm install -D husky lint-staged"
+      eval "npm install -D husky@4.3.8 lint-staged"
 
       INSERT_HERE=$(( $(wc -l < package.json) - 1 ))
 


### PR DESCRIPTION
Husky 5.0 changes how config works and will break the hooks created with this package. This rolls it back to the last pre 5.0 release: [4.3.8](https://github.com/typicode/husky/releases) 

Husky 5.0 was released on February 4th. [Hooks are no longer defined in package.json](https://dev.to/typicode/what-s-new-in-husky-5-32g5). 

While they have a [migration guide](https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v5) they have not updated their documentation for setting up anything other than the most basic config in the new version :/

Will update Playbook as well :)